### PR TITLE
Fix the issue that the publish_error test case fails to be executed.

### DIFF
--- a/tests/publish_error.py
+++ b/tests/publish_error.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import sys
 from threading import Thread
 from gi.repository import GLib, Gio
@@ -89,7 +90,7 @@ with bus.publish("net.lew21.pydbus.tests.Test", TestObject()):
 		try:
 			remote.Get("net.lew21.pydbus.tests.TestInterface", "Foo")
 		except ExceptionC as e:
-			assert str(e) == "No such property 'Foo'"
+			assert str(e) == "No such property “Foo”"
 
 		# Test default errors.
 		try:


### PR DESCRIPTION
The test case is successfully executed.
[root@localhost pydbus]# sh tests/run.sh python3
Main: t1
Main: t1
Lol: t2
Lol: t2
M1
M2
Obj: 1
Obj: 2
Obj: 3
asyn: Obj: 1
sync: Obj: 3
asyn: Obj: 2
Obj: 4
asyn: Obj: 4
