### PR TITLE
add make check for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 packages: wheel sdist
 
+PYTHON=python
+
 wheel:
 	rm -Rf build
 	./setup.py bdist_wheel
@@ -7,3 +9,7 @@ wheel:
 sdist:
 	rm -Rf build
 	./setup.py sdist
+
+check:
+	${PYTHON} setup.py install
+	sh tests/run.sh ${PYTHON}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -13,9 +13,28 @@ PYTHON=${1:-python}
 "$PYTHON" $TESTS_DIR/error.py
 if [ "$2" != "dontpublish" ]
 then
-	"$PYTHON" $TESTS_DIR/publish.py
-	"$PYTHON" $TESTS_DIR/publish_properties.py
-	"$PYTHON" $TESTS_DIR/publish_multiface.py
-	"$PYTHON" $TESTS_DIR/publish_async.py
-	"$PYTHON" $TESTS_DIR/publish_error.py
+	echo "====================================================================="
+	echo "TEST START"
+	all=0
+	xfail=0
+	xpass=0
+	for test_file in `ls $TESTS_DIR/publish*.py`
+	do
+	    all=`expr $all + 1`
+	    "$PYTHON" $test_file
+	    if [ $? -eq 0 ]; then
+	       echo "PASS: $test_file"
+	       xpass=`expr $xpass + 1`
+	    else
+	       echo "FAIL: $test_file"
+	       xfail=`expr $xfail + 1`
+	    fi
+	done
+	echo "TEST END"
+	echo "====================================================================="
+	echo "TEST RESULT SUMMARY for python-pydbus"
+	echo "# TOTAL: $all"
+	echo "# PASS:  $xpass"
+	echo "# FAIL:  $xfail"
+	echo "====================================================================="
 fi


### PR DESCRIPTION
#4 
You can execute tests with the following command:
make check   :  use default python to execute tests
make check PYTHON=python2  :  use python2 to execute tests
make check PYTHON=python3  :  use python3 to execute tests